### PR TITLE
Cover an edge case and ensure all structs implement Jason.Encoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ def start(_type, _args) do
 end
 ```
 
+### Note about Absinthe tracers
+
+In case your application uses Absinthe to implement GraphQL and you return structs from your
+resolvers, ensure that each of the structs implements the Jason.Encoder protocol.
+
 ## Installation
 
 The package can be installed by adding `mv_opentelemetry` to your list of

--- a/lib/mv_opentelemetry.ex
+++ b/lib/mv_opentelemetry.ex
@@ -12,12 +12,12 @@ defmodule MvOpentelemetry do
   # Somewhere in your application startup, for example in Application.start/2:
 
   def start(_type, _args) do
-    :ok = MvOpentelemetry.register_application(:mv_platform)
-    :ok = MvOpentelemetry.register_tracer(:ecto, span_prefix: [:mv_platform, :repo])
+    :ok = MvOpentelemetry.register_application(:my_app)
+    :ok = MvOpentelemetry.register_tracer(:ecto, span_prefix: [:my_app, :repo])
 
     :ok =
       MvOpentelemetry.register_tracer(:ecto,
-        span_prefix: [:mv_platform, :replica_repo],
+        span_prefix: [:my_app, :replica_repo],
         tracer_id: :replica
       )
 
@@ -25,6 +25,11 @@ defmodule MvOpentelemetry do
     :ok = MvOpentelemetry.register_tracer(:live_view)
   end
   ```
+
+  ## Note about Absinthe tracers
+
+  In case your application uses Absinthe to implement GraphQL and you return structs from your
+  resolvers, ensure that each of the structs implements the Jason.Encoder protocol.
   """
 
   @doc """
@@ -42,9 +47,10 @@ defmodule MvOpentelemetry do
   end
 
   @doc """
-  Registers tracer for given functional area. Allowed areas are: :ecto, :phoenix and :live_view
+  Registers tracer for given functional area. Allowed areas are: :ecto, :plug, :absinthe
+  and :live_view
   """
-  @spec register_tracer(:ecto | :phoenix | :live_view) :: :ok
+  @spec register_tracer(:ecto | :plug | :live_view | :absinthe) :: :ok
   def register_tracer(atom), do: register_tracer(atom, [])
 
   @doc """
@@ -67,8 +73,8 @@ defmodule MvOpentelemetry do
     live_view twice.
 
   ## Absinthe
-    - `name_prefix` OPTIONAL telemetry prefix that will be emited in events, for example
-    [:my_app, :graphql]
+    - `name_prefix` OPTIONAL telemetry prefix that will be emited in events, defaults to
+    [:absinthe]
     - `tracer_id` OPTIONAL atom to identify tracers in case you want to listen to events from
     Absinthe twice.
 

--- a/mv_opentelemetry_harness/lib/mv_opentelemetry_harness/human.ex
+++ b/mv_opentelemetry_harness/lib/mv_opentelemetry_harness/human.ex
@@ -1,0 +1,8 @@
+defmodule MvOpentelemetryHarness.Human do
+  alias MvOpentelemetryHarness.Pet
+
+  @derive Jason.Encoder
+  defstruct [:id, :name, :pets]
+
+  @type t() :: %__MODULE__{id: String.t(), name: String.t(), pets: [Pet.t()]}
+end

--- a/mv_opentelemetry_harness/lib/mv_opentelemetry_harness/pet.ex
+++ b/mv_opentelemetry_harness/lib/mv_opentelemetry_harness/pet.ex
@@ -1,0 +1,6 @@
+defmodule MvOpentelemetryHarness.Pet do
+  @derive Jason.Encoder
+  defstruct [:name]
+
+  @type t :: %__MODULE__{name: String.t()}
+end

--- a/mv_opentelemetry_harness/lib/mv_opentelemetry_harness_web/schema.ex
+++ b/mv_opentelemetry_harness/lib/mv_opentelemetry_harness_web/schema.ex
@@ -1,10 +1,13 @@
 defmodule MvOpentelemetryHarnessWeb.Schema do
   use Absinthe.Schema
 
+  alias MvOpentelemetryHarness.Pet
+  alias MvOpentelemetryHarness.Human
+
   # Example data
   @items %{
-    "foo" => %{id: "foo", name: "Stephen"},
-    "bar" => %{id: "bar", name: "Bar"}
+    "foo" => %Human{id: "foo", name: "Stephen"},
+    "bar" => %Human{id: "bar", name: "Bar"}
   }
 
   object :pet do
@@ -25,7 +28,7 @@ defmodule MvOpentelemetryHarnessWeb.Schema do
   end
 
   def pet_resolver(_map, _opts) do
-    {:ok, [%{name: "Pinky"}, %{name: "Brain"}]}
+    {:ok, [%Pet{name: "Pinky"}, %Pet{name: "Brain"}]}
   end
 
   query do

--- a/test/support/opentelemetry_case.ex
+++ b/test/support/opentelemetry_case.ex
@@ -30,8 +30,6 @@ defmodule MvOpentelemetry.OpenTelemetryCase do
       Sandbox.mode(Repo, {:shared, self()})
     end
 
-    conn = Phoenix.ConnTest.build_conn()
-
-    {:ok, conn: conn}
+    {:ok, conn: Phoenix.ConnTest.build_conn()}
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,2 @@
 ExUnit.start()
+Ecto.Adapters.SQL.Sandbox.mode(MvOpentelemetryHarness.Repo, :manual)


### PR DESCRIPTION
To work properly with absinthe, the structs must implement JSON decoder, this adds a note about that. The alternative would be to quietly implement encoding behind the scenes, but that is a lot more error prone.