### PR TITLE
Add reusable span tracer module

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,6 +1,7 @@
 approvers:
 - Vollmond
 - maciej-szlosarczyk
+- feliperenan
 reviewers:
 - Vollmond
 - maciej-szlosarczyk

--- a/lib/mv_opentelemetry.ex
+++ b/lib/mv_opentelemetry.ex
@@ -75,14 +75,13 @@ defmodule MvOpentelemetry do
     different repositories.
 
   ## LiveView
-    - `name_prefix` OPTIONAL telemetry prefix that will be emited in events, for example
-    [:my_app, :live_view]
-    - `tracer_id` OPTIONAL atom to identify tracers in case you want to listen to events from
+    - `prefix` OPTIONAL telemetry prefix that will be emited in events, for example
+    "my_app.phoenix". Defaults to "phoenix"
+    - `name` OPTIONAL atom to identify tracers in case you want to listen to events from
     live_view twice.
 
   ## Absinthe
-    - `name_prefix` OPTIONAL telemetry prefix that will be emited in events, defaults to
-    [:absinthe]
+    - `prefix` OPTIONAL telemetry prefix that will be emited in events, defaults to "absinthe"
 
   ## Plug
     - `span_prefix` OPTIONAL telemetry prefix to listen to. Defaults to [:phoenix, :endpoint]

--- a/lib/mv_opentelemetry/ecto.ex
+++ b/lib/mv_opentelemetry/ecto.ex
@@ -82,6 +82,8 @@ defmodule MvOpentelemetry.Ecto do
 
     Tracer.start_span(span_name, span_opts)
     |> Span.end_span()
+
+    :ok
   end
 
   defp name(config, event, source) do

--- a/lib/mv_opentelemetry/plug.ex
+++ b/lib/mv_opentelemetry/plug.ex
@@ -66,12 +66,12 @@ defmodule MvOpentelemetry.Plug do
 
     event_name = (opts[:name_prefix] ++ [String.downcase(conn.method)]) |> Enum.join(".")
 
-    OpentelemetryTelemetry.start_telemetry_span(@tracer_id, event_name, meta, %{})
+    OpentelemetryTelemetry.start_telemetry_span(opts[:tracer_id], event_name, meta, %{})
     |> Span.set_attributes(attributes)
   end
 
-  def handle_stop_event(_, _, %{conn: conn} = meta, _) do
-    ctx = OpentelemetryTelemetry.set_current_telemetry_span(@tracer_id, meta)
+  def handle_stop_event(_, _, %{conn: conn} = meta, opts) do
+    ctx = OpentelemetryTelemetry.set_current_telemetry_span(opts[:tracer_id], meta)
     Span.set_attribute(ctx, :"http.status", conn.status)
 
     if conn.status >= 400 do
@@ -79,7 +79,7 @@ defmodule MvOpentelemetry.Plug do
       Span.set_attributes(ctx, error: true)
     end
 
-    OpentelemetryTelemetry.end_telemetry_span(@tracer_id, meta)
+    OpentelemetryTelemetry.end_telemetry_span(opts[:tracer_id], meta)
   end
 
   defp client_ip(conn) do

--- a/lib/mv_opentelemetry/span_tracer.ex
+++ b/lib/mv_opentelemetry/span_tracer.ex
@@ -4,8 +4,8 @@ defmodule MvOpentelemetry.SpanTracer do
   converting them into OpenTelemetry traces.
 
   You can define custom tracers modules and then register them at the start of your application.
-  At minimum, you are required to implement `c:handle_event/4`, which has exactly the same
-  prerequisites as other telemetry handlers.
+  You are required to implement at least `c:handle_event/4` callback, which has exactly the same
+  type signature as BEAM telemetry handlers.
 
   ## Example
 
@@ -65,13 +65,13 @@ defmodule MvOpentelemetry.SpanTracer do
 
   ## Optional Parameters
 
-  * `:name` - atom to register the handler with. Defaults to module name, but can be overriden if
+  * `:name` - atom to register the handler with. Defaults to module name, but can be changed if
   needed.
   * `:prefix` - atom or string that can be used generate span name. Defaults to current module
   name.
   * `version` - string to version the tracer within OpenTelemetry. Defaults to "0.1.0"
 
-  All optional parameters can be also overriden in `c:register_tracer/1` call site:
+  All optional parameters can be also provided in `c:register_tracer/1` call site:
 
   ```
   def MyApp do

--- a/lib/mv_opentelemetry/span_tracer.ex
+++ b/lib/mv_opentelemetry/span_tracer.ex
@@ -1,0 +1,146 @@
+defmodule MvOpentelemetry.SpanTracer do
+  @moduledoc """
+  Reusable behaviour for listening to events emmited with `:telemetry.span/3` convention and
+  converting them into OpenTelemetry traces.
+
+  You can define custom tracers modules and then register them at the start of your application.
+  At minimum, you are required to implement `c:handle_event/4`, which has exactly the same
+  prerequisites as other telemetry handlers.
+
+  ## Example
+
+  ```
+  defmodule MyApp.SpanTracer do
+    use MvOpentelemetry.SpanTracer,
+      events: [[:my_event, :start], [:my_event, :stop], [:my_event, :exception]]
+
+    def handle_event([:my_event, :start], measurements, meta, opts) do
+      event_name = opts[:prefix]
+      attributes = ["my_event.name": meta.name]
+
+      OpentelemetryTelemetry.start_telemetry_span(opts[:name], event_name, meta, %{})
+      |> Span.set_attributes(attributes)
+
+      :ok
+    end
+
+    def handle_event([:my_event, :stop], measurements, meta, opts) do
+      ctx = OpentelemetryTelemetry.set_current_telemetry_span(opts[:name], meta)
+      OpentelemetryTelemetry.end_telemetry_span(opts[:name], meta)
+      :ok
+    end
+
+    def handle_event([:my_event, :exception], measurements, meta, opts) do
+      ctx = OpentelemetryTelemetry.set_current_telemetry_span(opts[:name], meta)
+      attributes = [reason: meta.reason, error: true, stacktrace: meta.stacktrace, kind: meta.kind]
+
+      OpenTelemetry.Span.set_attributes(ctx, attributes)
+      OpentelemetryTelemetry.end_telemetry_span(opts[:name], meta)
+
+      :ok
+    end
+  end
+
+  def MyApp do
+    def start(_type, _args) do
+      MyApp.SpanTracer.register_tracer()
+    end
+  end
+  ```
+
+  In the example above, the `c:register_tracer/1` is generated automatically, and when called it
+  will register the telemetry handler under `{MyApp.SpanTracer, MyApp.SpanTracer}`. The following
+  options will be merged with options provided to `c:register_tracer/1` and forwarded to
+  `c:handle_event/4` callback as config (4th argument).
+
+  ```
+  [version: "0.1.0", prefix: MyApp.SpanTracer, name: MyApp.SpanTracer]
+  ```
+
+  If you want to, you can also completely override the `c:register_tracer/1` callback.
+
+  ## Required parameters
+
+  * `:events` - a list of telemetry events you want the span to attach to.
+
+  ## Optional Parameters
+
+  * `:name` - atom to register the handler with. Defaults to module name, but can be overriden if
+  needed.
+  * `:prefix` - atom or string that can be used generate span name. Defaults to current module
+  name.
+  * `version` - string to version the tracer within OpenTelemetry. Defaults to "0.1.0"
+
+  All optional parameters can be also overriden in `c:register_tracer/1` call site:
+
+  ```
+  def MyApp do
+    def start(_type, _args) do
+      MyApp.SpanTracer.register_tracer(name: :test_span, version: "0.2.0", prefix: "other_tracer")
+    end
+  end
+  ```
+  """
+
+  @callback handle_event(
+              event :: [atom()],
+              measurements :: map(),
+              meta :: map(),
+              opts :: Access.t()
+            ) :: :ok
+
+  @callback register_tracer(opts :: Access.t()) :: :ok | {:error, :already_exists}
+
+  defmacro __using__(opts) do
+    events = Access.fetch!(opts, :events)
+    name = Access.get(opts, :name, __CALLER__.module)
+    prefix = Access.get(opts, :prefix, name)
+    tracer_version = Access.get(opts, :version, MvOpentelemetry.version())
+
+    quote location: :keep do
+      @behaviour MvOpentelemetry.SpanTracer
+
+      require OpenTelemetry.Tracer
+      require OpenTelemetry.Span
+
+      alias OpenTelemetry.Span
+
+      @spec register_tracer(Access.t()) :: :ok | {:error, :already_exists}
+      def register_tracer(opts \\ []) do
+        prefix = Access.get(opts, :prefix, unquote(prefix))
+        name = Access.get(opts, :name, unquote(name))
+        version = Access.get(opts, :version, unquote(tracer_version))
+
+        opts_with_defaults = merge_defaults(opts, prefix: prefix, name: name, version: version)
+
+        :opentelemetry.register_tracer(name, version)
+
+        :telemetry.attach_many(
+          {name, __MODULE__},
+          unquote(events),
+          &__MODULE__.handle_event/4,
+          opts_with_defaults
+        )
+      end
+
+      defp merge_defaults(opts, defaults) do
+        opts
+        |> merge_default(:name, defaults[:name])
+        |> merge_default(:prefix, defaults[:prefix])
+        |> merge_default(:version, defaults[:version])
+      end
+
+      def merge_default(opts, key, new_value) do
+        {_, new_container} =
+          Access.get_and_update(opts, key, fn
+            nil -> {nil, new_value}
+            some -> {some, some}
+          end)
+
+        new_container
+      end
+
+      defoverridable register_tracer: 1
+    end
+  end
+end

--- a/test/mv_opentelemetry/absinthe_test.exs
+++ b/test/mv_opentelemetry/absinthe_test.exs
@@ -3,7 +3,7 @@ defmodule MvOpentelemetry.AbsintheTest do
 
   test "sends otel events to pid", %{conn: conn} do
     :otel_batch_processor.set_exporter(:otel_exporter_pid, self())
-    MvOpentelemetry.Absinthe.register_tracer(tracer_id: :test_absinthe_tracer)
+    MvOpentelemetry.Absinthe.register_tracer(name: :test_absinthe_tracer)
 
     query = """
     query{
@@ -43,15 +43,12 @@ defmodule MvOpentelemetry.AbsintheTest do
     assert {:"graphql.field.name", "pets"} in attributes
     assert {:"graphql.field.schema", MvOpentelemetryHarnessWeb.Schema} in attributes
 
-    :ok = :telemetry.detach({:test_absinthe_tracer, MvOpentelemetry.Absinthe, :handle_stop_event})
-
-    :ok =
-      :telemetry.detach({:test_absinthe_tracer, MvOpentelemetry.Absinthe, :handle_start_event})
+    :ok = :telemetry.detach({:test_absinthe_tracer, MvOpentelemetry.Absinthe})
   end
 
   test "sends error data to pid", %{conn: conn} do
     :otel_batch_processor.set_exporter(:otel_exporter_pid, self())
-    MvOpentelemetry.Absinthe.register_tracer(tracer_id: :test_absinthe_error_tracer)
+    MvOpentelemetry.Absinthe.register_tracer(name: :test_absinthe_error_tracer)
 
     # Here be error
     query = """
@@ -84,14 +81,6 @@ defmodule MvOpentelemetry.AbsintheTest do
     assert {:"graphql.operation.input", query} in attributes
     assert {:"graphql.operation.schema", MvOpentelemetryHarnessWeb.Schema} in attributes
 
-    :ok =
-      :telemetry.detach(
-        {:test_absinthe_error_tracer, MvOpentelemetry.Absinthe, :handle_stop_event}
-      )
-
-    :ok =
-      :telemetry.detach(
-        {:test_absinthe_error_tracer, MvOpentelemetry.Absinthe, :handle_start_event}
-      )
+    :ok = :telemetry.detach({:test_absinthe_error_tracer, MvOpentelemetry.Absinthe})
   end
 end

--- a/test/mv_opentelemetry/live_view_test.exs
+++ b/test/mv_opentelemetry/live_view_test.exs
@@ -4,7 +4,7 @@ defmodule MvOpentelemetry.LiveViewTest do
 
   test "sends OpenTelemetry events to pid()", %{conn: conn} do
     :otel_batch_processor.set_exporter(:otel_exporter_pid, self())
-    MvOpentelemetry.LiveView.register_tracer(tracer_id: :test_live_view_tracer)
+    MvOpentelemetry.LiveView.register_tracer(name: :test_live_view_tracer)
 
     assert {:ok, _view, html} = live(conn, "/live?live_id=11")
     assert html =~ "LiveLive"
@@ -21,6 +21,6 @@ defmodule MvOpentelemetry.LiveViewTest do
     assert {:"live_view.view", MvOpentelemetryHarnessWeb.LiveLive} in attributes
     assert {:"live_view.params", %{"live_id" => "11"}} in attributes
 
-    :ok = :telemetry.detach({:test_live_view_tracer, MvOpentelemetry.LiveView, :handle_event})
+    :ok = :telemetry.detach({:test_live_view_tracer, MvOpentelemetry.LiveView})
   end
 end

--- a/test/mv_opentelemetry/span_tracer_test.exs
+++ b/test/mv_opentelemetry/span_tracer_test.exs
@@ -1,0 +1,39 @@
+defmodule MvOpentelemetry.SpanTracerTest do
+  use MvOpentelemetry.OpenTelemetryCase
+
+  alias MvOpentelemetry.CustomSpanTracer
+
+  test "it captures the event" do
+    :otel_batch_processor.set_exporter(:otel_exporter_pid, self())
+    CustomSpanTracer.register_tracer()
+
+    :telemetry.span([:my_event, :do_stuff], %{name: "custom"}, fn ->
+      {:ok, %{result: :success}}
+    end)
+
+    assert_receive {:span, span_record}
+    assert "my_event.do_stuff" == span(span_record, :name)
+    attributes = span(span_record, :attributes)
+    assert {:"my_event.name", "custom"} in attributes
+    assert {:"my_event.result", :success} in attributes
+
+    :ok = :telemetry.detach({CustomSpanTracer, CustomSpanTracer})
+  end
+
+  test "it captures the exception" do
+    :otel_batch_processor.set_exporter(:otel_exporter_pid, self())
+    CustomSpanTracer.register_tracer()
+
+    try do
+      CustomSpanTracer.raise_test_error()
+    rescue
+      RuntimeError ->
+        assert_receive {:span, span_record}
+        assert "my_event.do_stuff" == span(span_record, :name)
+        attributes = span(span_record, :attributes)
+        assert {:error, true} in attributes
+        assert {:kind, :error} in attributes
+        :ok = :telemetry.detach({CustomSpanTracer, CustomSpanTracer})
+    end
+  end
+end

--- a/test/support/custom_span_tracer.ex
+++ b/test/support/custom_span_tracer.ex
@@ -1,0 +1,47 @@
+defmodule MvOpentelemetry.CustomSpanTracer do
+  @moduledoc false
+
+  use MvOpentelemetry.SpanTracer,
+    events: [
+      [:my_event, :do_stuff, :start],
+      [:my_event, :do_stuff, :stop],
+      [:my_event, :do_stuff, :exception]
+    ]
+
+  def handle_event([:my_event, :do_stuff, :start], _measurements, meta, opts) do
+    event_name = "my_event.do_stuff"
+    attributes = ["my_event.name": meta.name]
+
+    OpentelemetryTelemetry.start_telemetry_span(opts[:name], event_name, meta, %{})
+    |> Span.set_attributes(attributes)
+
+    :ok
+  end
+
+  def handle_event([:my_event, :do_stuff, :stop], _measurements, meta, opts) do
+    ctx = OpentelemetryTelemetry.set_current_telemetry_span(opts[:name], meta)
+    attributes = ["my_event.result": meta.result]
+
+    Span.set_attributes(ctx, attributes)
+    OpentelemetryTelemetry.end_telemetry_span(opts[:name], meta)
+
+    :ok
+  end
+
+  def handle_event([:my_event, :do_stuff, :exception], _measurements, meta, opts) do
+    ctx = OpentelemetryTelemetry.set_current_telemetry_span(opts[:name], meta)
+
+    attributes = [reason: meta.reason, error: true, stacktrace: meta.stacktrace, kind: meta.kind]
+
+    Span.set_attributes(ctx, attributes)
+    OpentelemetryTelemetry.end_telemetry_span(opts[:name], meta)
+
+    :ok
+  end
+
+  def raise_test_error do
+    :telemetry.span([:my_event, :do_stuff], %{name: "custom"}, fn ->
+      raise "boo!"
+    end)
+  end
+end


### PR DESCRIPTION
This adds a reusable tracer module, which in example of the custom tracer we use in stories, shortens it from 90 to 55 lines of code. Also in use here in absinthe and liveview tracers.

Signed-off-by: Maciej Szlosarczyk <maciej@mindvalley.com>