### PR TITLE
Add default attributes handling

### DIFF
--- a/lib/mv_opentelemetry.ex
+++ b/lib/mv_opentelemetry.ex
@@ -18,10 +18,6 @@ defmodule MvOpentelemetry do
     :ok = MvOpentelemetry.register_tracer(:live_view)
   end
 
-  ## Note about Absinthe tracers
-
-  In case your application uses Absinthe to implement GraphQL and you return structs from your
-  resolvers, ensure that each of the structs implements the MvOpentelemetry.Sanitizer protocol.
   ```
   """
 
@@ -47,21 +43,31 @@ defmodule MvOpentelemetry do
   ## Ecto
     - `span_prefix` REQUIRED telemetry prefix to listen to. If you're unsure of what to put here,
     [:my_app, :repo] is the right choice.
+    - `default_attributes` OPTIONAL property list of attributes you want to attach to all traces
+      from this group, for example [{"service.component", "my_app"}]. Defaults to []
 
   ## LiveView
     - `prefix` OPTIONAL telemetry prefix that will be emited in events, for example
     "my_app.phoenix". Defaults to "phoenix"
     - `name` OPTIONAL atom to identify tracers in case you want to listen to events from
     live_view twice.
+    - `default_attributes` OPTIONAL property list of attributes you want to attach to all traces
+      from this group, for example [{"service.component", "my_app"}]. Defaults to []
 
   ## Absinthe
-    - `prefix` OPTIONAL telemetry prefix that will be emited in events, defaults to "absinthe"
+    - `prefix` OPTIONAL telemetry prefix that will be emited in events, defaults to "graphql"
+    - `default_attributes` OPTIONAL property list of attributes you want to attach to all traces
+      from this group, for example [{"service.component", "ecto"}]. Defaults to []
 
   ## Dataloader
-  Accepts no arguments.
+    - `default_attributes` OPTIONAL property list of attributes you want to attach to all traces
+      from this group, for example [{"service.component", "ecto"}]. Defaults to []
 
   ## Plug
     - `span_prefix` OPTIONAL telemetry prefix to listen to. Defaults to [:phoenix, :endpoint]
+    - `default_attributes` OPTIONAL property list of attributes you want to attach to all traces
+      from this group, for example [{"service.component", "ecto"}]. Defaults to []
+
   """
   @spec register_tracer(:absinthe | :dataloader | :ecto | :plug | :live_view, Access.t()) :: :ok
   def register_tracer(:absinthe, opts), do: MvOpentelemetry.Absinthe.register_tracer(opts)

--- a/lib/mv_opentelemetry/absinthe.ex
+++ b/lib/mv_opentelemetry/absinthe.ex
@@ -34,6 +34,8 @@ defmodule MvOpentelemetry.Absinthe do
       {"graphql.field.schema", resolution.schema}
     ]
 
+    attributes = attributes ++ opts[:default_attributes]
+
     OpentelemetryTelemetry.start_telemetry_span(opts[:tracer_id], event_name, meta, %{})
     |> Span.set_attributes(attributes)
 
@@ -43,7 +45,7 @@ defmodule MvOpentelemetry.Absinthe do
   def handle_event([:absinthe, :execute, :operation, :start], _measurements, meta, opts) do
     event_name = Enum.join([opts[:prefix]] ++ [:execute, :operation], ".")
 
-    attributes = [{"graphql.operation.input", meta.blueprint.input}]
+    attributes = [{"graphql.operation.input", meta.blueprint.input}] ++ opts[:default_attributes]
 
     OpentelemetryTelemetry.start_telemetry_span(opts[:tracer_id], event_name, meta, %{})
     |> Span.set_attributes(attributes)

--- a/lib/mv_opentelemetry/dataloader.ex
+++ b/lib/mv_opentelemetry/dataloader.ex
@@ -10,9 +10,11 @@ defmodule MvOpentelemetry.Dataloader do
     ]
 
   @spec handle_event([atom()], map(), map(), Access.t()) :: :ok
-  def handle_event([:dataloader, :source, :run, :start], _measurements, meta, _opts) do
+  def handle_event([:dataloader, :source, :run, :start], _measurements, meta, opts) do
     event_name = "dataloader.source.run"
+
     OpentelemetryTelemetry.start_telemetry_span(__MODULE__, event_name, meta, %{})
+    |> Span.set_attributes(opts[:default_attributes])
 
     :ok
   end
@@ -22,9 +24,11 @@ defmodule MvOpentelemetry.Dataloader do
     :ok
   end
 
-  def handle_event([:dataloader, :source, :batch, :run, :start], _measurements, meta, _opts) do
+  def handle_event([:dataloader, :source, :batch, :run, :start], _measurements, meta, opts) do
     event_name = "dataloader.source.batch.run"
+
     OpentelemetryTelemetry.start_telemetry_span(__MODULE__, event_name, meta, %{})
+    |> Span.set_attributes(opts[:default_attributes])
 
     :ok
   end

--- a/lib/mv_opentelemetry/ecto.ex
+++ b/lib/mv_opentelemetry/ecto.ex
@@ -25,7 +25,9 @@ defmodule MvOpentelemetry.Ecto do
       opts[:span_prefix] ||
         raise MvOpentelemetry.Error, message: "span_prefix is required", module: __MODULE__
 
-    [span_prefix: span_prefix]
+    default_attributes = opts[:default_attributes] || []
+
+    [span_prefix: span_prefix, default_attributes: default_attributes]
   end
 
   @spec handle_event([atom()], map(), map(), Access.t()) :: :ok
@@ -63,7 +65,11 @@ defmodule MvOpentelemetry.Ecto do
       {"db.total_time_microseconds", convert_time(total_time)}
     ]
 
-    all_attributes = result ++ base_attributes ++ time_attributes(measurements)
+    default_attributes = config[:default_attributes]
+
+    all_attributes =
+      default_attributes ++ result ++ base_attributes ++ time_attributes(measurements)
+
     span_name = name(config, event, source)
     span_opts = %{start_time: start_time, attributes: all_attributes, kind: :client}
 

--- a/lib/mv_opentelemetry/live_view.ex
+++ b/lib/mv_opentelemetry/live_view.ex
@@ -27,7 +27,7 @@ defmodule MvOpentelemetry.LiveView do
     attributes = [{"live_view.view", meta.socket.view}]
 
     params_attributes = Enum.map(meta.params, &prefix_key_with(&1, "live_view.params"))
-    attributes = attributes ++ params_attributes
+    attributes = attributes ++ params_attributes ++ opts[:default_attributes]
 
     name = get_name(event, opts)
 
@@ -46,7 +46,7 @@ defmodule MvOpentelemetry.LiveView do
     attributes = [{"live_view.view", meta.socket.view}, {"live_view.uri", meta.uri}]
 
     params_attributes = Enum.map(meta.params, &prefix_key_with(&1, "live_view.params"))
-    attributes = attributes ++ params_attributes
+    attributes = attributes ++ params_attributes ++ opts[:default_attributes]
 
     name = get_name(event, opts)
 
@@ -71,7 +71,7 @@ defmodule MvOpentelemetry.LiveView do
     name = get_name(event, opts)
 
     params_attributes = Enum.map(meta.params, &prefix_key_with(&1, "live_view.params"))
-    attributes = attributes ++ params_attributes
+    attributes = attributes ++ params_attributes ++ opts[:default_attributes]
 
     OpentelemetryTelemetry.start_telemetry_span(opts[:tracer_id], name, meta, %{})
     |> Span.set_attributes(attributes)
@@ -94,6 +94,8 @@ defmodule MvOpentelemetry.LiveView do
     ]
 
     name = get_name(event, opts)
+
+    attributes = attributes ++ opts[:default_attributes]
 
     OpentelemetryTelemetry.start_telemetry_span(opts[:tracer_id], name, meta, %{})
     |> Span.set_attributes(attributes)

--- a/lib/mv_opentelemetry/plug.ex
+++ b/lib/mv_opentelemetry/plug.ex
@@ -28,8 +28,9 @@ defmodule MvOpentelemetry.Plug do
   defp handle_opts(opts) do
     span_prefix = opts[:span_prefix] || [:phoenix, :endpoint]
     tracer_id = :mv_opentelemetry
+    default_attributes = opts[:default_attributes] || []
 
-    [span_prefix: span_prefix, tracer_id: tracer_id]
+    [span_prefix: span_prefix, tracer_id: tracer_id, default_attributes: default_attributes]
   end
 
   @spec handle_start_event(_ :: any(), _ :: any(), %{conn: Plug.Conn.t()}, Access.t()) :: :ok
@@ -63,7 +64,7 @@ defmodule MvOpentelemetry.Plug do
     query_attributes = Enum.map(conn.query_params, &prefix_key_with(&1, "http.query_params"))
     path_attributes = Enum.map(conn.path_params, &prefix_key_with(&1, "http.path_params"))
 
-    attributes = attributes ++ query_attributes ++ path_attributes
+    attributes = attributes ++ query_attributes ++ path_attributes ++ opts[:default_attributes]
 
     event_name = "HTTP #{conn.method}"
 

--- a/lib/mv_opentelemetry/span_tracer.ex
+++ b/lib/mv_opentelemetry/span_tracer.ex
@@ -95,6 +95,7 @@ defmodule MvOpentelemetry.SpanTracer do
     events = Access.fetch!(opts, :events)
     name = Access.get(opts, :name, __CALLER__.module)
     prefix = Access.get(opts, :prefix, name)
+    default_attributes = Access.get(opts, :default_attributes, [])
     tracer_version = Access.get(opts, :version, MvOpentelemetry.version())
 
     quote location: :keep do
@@ -110,10 +111,17 @@ defmodule MvOpentelemetry.SpanTracer do
         prefix = Access.get(opts, :prefix, unquote(prefix))
         name = Access.get(opts, :name, unquote(name))
         version = Access.get(opts, :version, unquote(tracer_version))
+        default_attributes = Access.get(opts, :default_attributes, unquote(default_attributes))
         tracer_id = :mv_opentelemetry
 
         opts_with_defaults =
-          merge_defaults(opts, prefix: prefix, name: name, version: version, tracer_id: tracer_id)
+          merge_defaults(opts,
+            prefix: prefix,
+            name: name,
+            version: version,
+            tracer_id: tracer_id,
+            default_attributes: default_attributes
+          )
 
         :telemetry.attach_many(
           {name, __MODULE__},
@@ -129,6 +137,7 @@ defmodule MvOpentelemetry.SpanTracer do
         |> merge_default(:prefix, defaults[:prefix])
         |> merge_default(:version, defaults[:version])
         |> merge_default(:tracer_id, defaults[:tracer_id])
+        |> merge_default(:default_attributes, defaults[:default_attributes])
       end
 
       def merge_default(opts, key, new_value) do

--- a/test/mv_opentelemetry/absinthe_test.exs
+++ b/test/mv_opentelemetry/absinthe_test.exs
@@ -3,7 +3,11 @@ defmodule MvOpentelemetry.AbsintheTest do
 
   test "sends otel events to pid", %{conn: conn} do
     :otel_batch_processor.set_exporter(:otel_exporter_pid, self())
-    MvOpentelemetry.Absinthe.register_tracer(name: :test_absinthe_tracer)
+
+    MvOpentelemetry.Absinthe.register_tracer(
+      name: :test_absinthe_tracer,
+      default_attributes: [{"service.component", "test.harness"}]
+    )
 
     query = """
     query{
@@ -34,6 +38,7 @@ defmodule MvOpentelemetry.AbsintheTest do
     {:attributes, _, _, _, attributes} = span(span_record, :attributes)
 
     assert {"graphql.field.name", "human"} in attributes
+    assert {"service.component", "test.harness"} in attributes
     assert {"graphql.field.schema", MvOpentelemetryHarnessWeb.Schema} in attributes
 
     assert_receive {:span, span_record}
@@ -41,6 +46,7 @@ defmodule MvOpentelemetry.AbsintheTest do
     {:attributes, _, _, _, attributes} = span(span_record, :attributes)
 
     assert {"graphql.field.name", "pets"} in attributes
+    assert {"service.component", "test.harness"} in attributes
     assert {"graphql.field.schema", MvOpentelemetryHarnessWeb.Schema} in attributes
 
     :ok = :telemetry.detach({:test_absinthe_tracer, MvOpentelemetry.Absinthe})

--- a/test/mv_opentelemetry/ecto_test.exs
+++ b/test/mv_opentelemetry/ecto_test.exs
@@ -6,7 +6,8 @@ defmodule MvOpentelemetry.EctoTest do
 
     MvOpentelemetry.Ecto.register_tracer(
       tracer_id: :test_ecto_tracer,
-      span_prefix: [:mv_opentelemetry_harness, :repo]
+      span_prefix: [:mv_opentelemetry_harness, :repo],
+      default_attributes: [{"service.component", "test.harness"}]
     )
 
     MvOpentelemetryHarness.Page.all() |> MvOpentelemetryHarness.Repo.all()
@@ -18,6 +19,7 @@ defmodule MvOpentelemetry.EctoTest do
 
     assert {"db.source", "pages"} in attributes
     assert {"db.type", :sql} in attributes
+    assert {"service.component", "test.harness"} in attributes
     assert "db.statement" in keys
     assert "db.instance" in keys
     assert "db.url" in keys

--- a/test/mv_opentelemetry/live_view_test.exs
+++ b/test/mv_opentelemetry/live_view_test.exs
@@ -4,7 +4,11 @@ defmodule MvOpentelemetry.LiveViewTest do
 
   test "sends OpenTelemetry events to pid()", %{conn: conn} do
     :otel_batch_processor.set_exporter(:otel_exporter_pid, self())
-    MvOpentelemetry.LiveView.register_tracer(name: :test_live_view_tracer)
+
+    MvOpentelemetry.LiveView.register_tracer(
+      name: :test_live_view_tracer,
+      default_attributes: [{"potatoeh", "potatoe"}]
+    )
 
     assert {:ok, _view, html} = live(conn, "/live?live_id=11")
     assert html =~ "LiveLive"
@@ -13,6 +17,7 @@ defmodule MvOpentelemetry.LiveViewTest do
     {:attributes, _, _, _, attributes} = span(span_record, :attributes)
 
     assert {"live_view.view", MvOpentelemetryHarnessWeb.LiveLive} in attributes
+    assert {"potatoeh", "potatoe"} in attributes
     assert {"live_view.params.live_id", "11"} in attributes
 
     assert_receive {:span, span(name: "phoenix.live_view.handle_params") = span_record}
@@ -20,6 +25,7 @@ defmodule MvOpentelemetry.LiveViewTest do
 
     assert {"live_view.view", MvOpentelemetryHarnessWeb.LiveLive} in attributes
     assert {"live_view.params.live_id", "11"} in attributes
+    assert {"potatoeh", "potatoe"} in attributes
 
     :ok = :telemetry.detach({:test_live_view_tracer, MvOpentelemetry.LiveView})
   end

--- a/test/mv_opentelemetry/plug_test.exs
+++ b/test/mv_opentelemetry/plug_test.exs
@@ -3,7 +3,11 @@ defmodule MvOpentelemetry.PlugTest do
 
   test "handles successful requests in stories-specific context", %{conn: conn} do
     :otel_batch_processor.set_exporter(:otel_exporter_pid, self())
-    MvOpentelemetry.Plug.register_tracer(span_prefix: [:harness, :request])
+
+    MvOpentelemetry.Plug.register_tracer(
+      span_prefix: [:harness, :request],
+      default_attributes: [{"service.component", "test.harness"}]
+    )
 
     conn
     |> put_req_header("user-agent", "Phoenix Test")
@@ -18,6 +22,7 @@ defmodule MvOpentelemetry.PlugTest do
     assert {"http.method", "GET"} in attributes
     assert {"http.flavor", ""} in attributes
     assert {"http.target", "/"} in attributes
+    assert {"service.component", "test.harness"} in attributes
     assert {"http.query_params.query", "1234"} in attributes
     assert {"http.query_params.user_id", ""} in attributes
     assert {"http.user_agent", "Phoenix Test"} in attributes


### PR DESCRIPTION
Fixes #15 (somewhat) - the service.name attribute is reserved for all horizontal instances of the same binary (therefore it cannot be changed), but with this in place you can add `[{"component", "api"}]` to each specific trace provider.

FYI @onimsha

Signed-off-by: Maciej Szlosarczyk <maciej@mindvalley.com>