### PR TITLE
Do not record field resolution events from GraphQL

### DIFF
--- a/lib/mv_opentelemetry.ex
+++ b/lib/mv_opentelemetry.ex
@@ -32,9 +32,6 @@ defmodule MvOpentelemetry do
   @spec register_tracer(:ecto | :plug | :live_view | :absinthe | :dataloader) :: :ok
   def register_tracer(atom), do: register_tracer(atom, [])
 
-  @doc false
-  def version, do: "1.1.1"
-
   @doc """
   Registers tracer for given functional area with options.
   Allowed areas are: :absinthe, :dataloader, :ecto, :phoenix and :live_view.
@@ -60,6 +57,8 @@ defmodule MvOpentelemetry do
     - `prefix` OPTIONAL telemetry prefix that will be emited in events, defaults to "graphql"
     - `default_attributes` OPTIONAL property list of attributes you want to attach to all traces
       from this group, for example [{"service.component", "ecto"}]. Defaults to []
+    - `include_field_resolution` OPTIONAL boolean for subscribing to field resolution events.
+      These tend to be noisy and produce a lot of spans, so the default is set to `false`
 
   ## Dataloader
     - `default_attributes` OPTIONAL property list of attributes you want to attach to all traces

--- a/lib/mv_opentelemetry/span_tracer.ex
+++ b/lib/mv_opentelemetry/span_tracer.ex
@@ -127,6 +127,10 @@ defmodule MvOpentelemetry.SpanTracer do
         )
       end
 
+      defp __opts__ do
+        unquote(opts)
+      end
+
       defp merge_defaults(opts, defaults) do
         opts
         |> merge_default(:name, defaults[:name])

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule MvOpentelemetry.MixProject do
   def project do
     [
       app: :mv_opentelemetry,
-      version: "1.1.1",
+      version: "1.2.0",
       elixir: "~> 1.7",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: Mix.compilers(),


### PR DESCRIPTION
The explanation for this is a little bit complex. The collector
written in go provides interesting functionality to sample events
based on various criteria (status, probabilistic distribution etc)
but it operates on the level of trace (a graph of many spans) and it
can drop the whole graph all at once.

For our noisy GraphQL events, we actually want the trace to be
preserved, but at the same time, do not record too many spans when it
is not necessary.

This introduces a flag that does exactly that - by default, all spans
from field resolution events will be dropped and not taken into
account. We can enable them by passing `include_field_resolution:
true` to the absinthe tracer initialization.

Signed-off-by: Maciej Szlosarczyk <maciej@mindvalley.com>

Fixes #16 