### PR TITLE
Only use peer data when Plug is a dependency

### DIFF
--- a/lib/mv_opentelemetry/plug.ex
+++ b/lib/mv_opentelemetry/plug.ex
@@ -45,7 +45,14 @@ defmodule MvOpentelemetry.Plug do
 
     request_id = :proplists.get_value("x-request-id", conn.resp_headers, "")
     user_agent = :proplists.get_value("user-agent", conn.req_headers, "")
-    peer_data = Plug.Conn.get_peer_data(conn)
+
+    peer_data =
+      if function_exported?(Plug.Conn, :get_peer_data, 1) do
+        Plug.Conn.get_peer_data(conn)
+      else
+        %{}
+      end
+
     peer_ip = Map.get(peer_data, :address)
     referer = :proplists.get_value("referer", conn.req_headers, "")
     client_ip = client_ip(conn)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule MvOpentelemetry.MixProject do
   def project do
     [
       app: :mv_opentelemetry,
-      version: "1.2.0",
+      version: "1.2.1",
       elixir: "~> 1.7",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: Mix.compilers(),
@@ -45,6 +45,7 @@ defmodule MvOpentelemetry.MixProject do
       {:opentelemetry_exporter, "~> 1.0", only: [:dev, :test]},
       {:mv_opentelemetry_harness, path: "./mv_opentelemetry_harness", only: [:dev, :test]},
       {:phoenix_live_reload, "~> 1.2", only: :dev},
+      {:plug, "~> 1.0", optional: true},
       {:floki, ">= 0.30.0", only: :test},
       {:credo, "~> 1.5", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.0", only: [:dev, :test], runtime: false}

--- a/test/mv_opentelemetry/absinthe_test.exs
+++ b/test/mv_opentelemetry/absinthe_test.exs
@@ -34,16 +34,14 @@ defmodule MvOpentelemetry.AbsintheTest do
              }
            }
 
-    assert_receive {:span, span_record}
-    assert "graphql.resolve.field.human" == span(span_record, :name)
+    assert_receive {:span, span(name: "graphql.resolve.field.human") = span_record}
     {:attributes, _, _, _, attributes} = span(span_record, :attributes)
 
     assert {"graphql.field.name", "human"} in attributes
     assert {"service.component", "test.harness"} in attributes
     assert {"graphql.field.schema", MvOpentelemetryHarnessWeb.Schema} in attributes
 
-    assert_receive {:span, span_record}
-    assert "graphql.resolve.field.pets" == span(span_record, :name)
+    assert_receive {:span, span(name: "graphql.resolve.field.pets") = span_record}
     {:attributes, _, _, _, attributes} = span(span_record, :attributes)
 
     assert {"graphql.field.name", "pets"} in attributes
@@ -82,8 +80,7 @@ defmodule MvOpentelemetry.AbsintheTest do
              }
            }
 
-    assert_receive {:span, span_record}
-    assert "graphql.execute.operation" == span(span_record, :name)
+    assert_receive {:span, span(name: "graphql.execute.operation") = span_record}
     {:attributes, _, _, _, attributes} = span(span_record, :attributes)
 
     assert {"graphql.operation.input", query} in attributes
@@ -120,8 +117,7 @@ defmodule MvOpentelemetry.AbsintheTest do
              ]
            }
 
-    assert_receive {:span, span_record}
-    assert "graphql.execute.operation" == span(span_record, :name)
+    assert_receive {:span, span(name: "graphql.execute.operation") = span_record}
     {:attributes, _, _, _, attributes} = span(span_record, :attributes)
 
     assert {"graphql.operation.input", query} in attributes


### PR DESCRIPTION
In practice this should not happen, but removes the noisy compilation warning when using mv_opentelemetry as a dependency and it gets compiled before Plug.

Signed-off-by: Maciej Szlosarczyk <maciej@mindvalley.com>