### PR TITLE
Restart app between tests

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -26,8 +26,6 @@ config :logger, :console,
 # Use Jason for JSON parsing in Phoenix
 config :phoenix, :json_library, Jason
 
-config :opentelemetry, processors: [otel_batch_processor: %{scheduled_delay_ms: 1}]
-
 # Configure your database
 #
 # The MIX_TEST_PARTITION environment variable can be used

--- a/test/mv_opentelemetry/absinthe_test.exs
+++ b/test/mv_opentelemetry/absinthe_test.exs
@@ -2,8 +2,6 @@ defmodule MvOpentelemetry.AbsintheTest do
   use MvOpentelemetry.OpenTelemetryCase
 
   test "sends field events when asked for it", %{conn: conn} do
-    :otel_batch_processor.set_exporter(:otel_exporter_pid, self())
-
     MvOpentelemetry.Absinthe.register_tracer(
       name: :test_absinthe_tracer,
       default_attributes: [{"service.component", "test.harness"}],
@@ -52,8 +50,6 @@ defmodule MvOpentelemetry.AbsintheTest do
   end
 
   test "sends only top-level events", %{conn: conn} do
-    :otel_batch_processor.set_exporter(:otel_exporter_pid, self())
-
     MvOpentelemetry.Absinthe.register_tracer(name: :test_absinthe_tracer)
 
     query = """
@@ -90,7 +86,6 @@ defmodule MvOpentelemetry.AbsintheTest do
   end
 
   test "sends error data to pid", %{conn: conn} do
-    :otel_batch_processor.set_exporter(:otel_exporter_pid, self())
     MvOpentelemetry.Absinthe.register_tracer(name: :test_absinthe_error_tracer)
 
     # Here be error

--- a/test/mv_opentelemetry/broadway/messages_test.exs
+++ b/test/mv_opentelemetry/broadway/messages_test.exs
@@ -4,8 +4,6 @@ defmodule MvOpentelemetry.Broadway.MessagesTest do
   alias MvOpentelemetryHarness.BroadwayDummy
 
   test "sends otel events to pid" do
-    :otel_batch_processor.set_exporter(:otel_exporter_pid, self())
-
     Messages.register_tracer(
       name: :test_broadway_tracer,
       default_attributes: [{"service.component", "test.harness"}]

--- a/test/mv_opentelemetry/dataloader_test.exs
+++ b/test/mv_opentelemetry/dataloader_test.exs
@@ -16,8 +16,6 @@ defmodule MvOpentelemetry.DataloaderTest do
   end
 
   test "sends batch events", %{dataloader: loader} do
-    :otel_batch_processor.set_exporter(:otel_exporter_pid, self())
-
     MvOpentelemetry.Dataloader.register_tracer(
       name: :test_dataloader_tracer,
       default_attributes: [{"service.component", "test.harness"}]
@@ -53,8 +51,6 @@ defmodule MvOpentelemetry.DataloaderTest do
   end
 
   test "sends source events", %{dataloader: loader} do
-    :otel_batch_processor.set_exporter(:otel_exporter_pid, self())
-
     MvOpentelemetry.Dataloader.register_tracer(
       name: :test_dataloader_tracer,
       default_attributes: [{"service.component", "test.harness"}]

--- a/test/mv_opentelemetry/ecto_test.exs
+++ b/test/mv_opentelemetry/ecto_test.exs
@@ -2,8 +2,6 @@ defmodule MvOpentelemetry.EctoTest do
   use MvOpentelemetry.OpenTelemetryCase
 
   test "sends otel events to pid" do
-    :otel_batch_processor.set_exporter(:otel_exporter_pid, self())
-
     MvOpentelemetry.Ecto.register_tracer(
       tracer_id: :test_ecto_tracer,
       span_prefix: [:mv_opentelemetry_harness, :repo],
@@ -30,8 +28,6 @@ defmodule MvOpentelemetry.EctoTest do
   end
 
   test "raises when span_prefix is not given" do
-    :otel_batch_processor.set_exporter(:otel_exporter_pid, self())
-
     assert_raise MvOpentelemetry.Error, "span_prefix is required", fn ->
       MvOpentelemetry.Ecto.register_tracer([])
     end

--- a/test/mv_opentelemetry/live_view_test.exs
+++ b/test/mv_opentelemetry/live_view_test.exs
@@ -3,8 +3,6 @@ defmodule MvOpentelemetry.LiveViewTest do
   import Phoenix.LiveViewTest
 
   test "sends OpenTelemetry events to pid()", %{conn: conn} do
-    :otel_batch_processor.set_exporter(:otel_exporter_pid, self())
-
     MvOpentelemetry.LiveView.register_tracer(
       name: :test_live_view_tracer,
       default_attributes: [{"potatoeh", "potatoe"}]
@@ -31,8 +29,6 @@ defmodule MvOpentelemetry.LiveViewTest do
   end
 
   test "allows for setting query params whitelist", %{conn: conn} do
-    :otel_batch_processor.set_exporter(:otel_exporter_pid, self())
-
     MvOpentelemetry.LiveView.register_tracer(
       name: :test_live_view_tracer,
       query_params_whitelist: ["user_id"]

--- a/test/mv_opentelemetry/plug_test.exs
+++ b/test/mv_opentelemetry/plug_test.exs
@@ -2,8 +2,6 @@ defmodule MvOpentelemetry.PlugTest do
   use MvOpentelemetry.OpenTelemetryCase
 
   test "handles successful requests in stories-specific context", %{conn: conn} do
-    :otel_batch_processor.set_exporter(:otel_exporter_pid, self())
-
     MvOpentelemetry.Plug.register_tracer(
       span_prefix: [:harness, :request],
       default_attributes: [{"service.component", "test.harness"}]
@@ -38,8 +36,6 @@ defmodule MvOpentelemetry.PlugTest do
   end
 
   test "allows for setting a force trace header", %{conn: conn} do
-    :otel_batch_processor.set_exporter(:otel_exporter_pid, self())
-
     MvOpentelemetry.Plug.register_tracer(span_prefix: [:harness, :request])
 
     conn
@@ -63,8 +59,6 @@ defmodule MvOpentelemetry.PlugTest do
   end
 
   test "allows for setting query params whitelist", %{conn: conn} do
-    :otel_batch_processor.set_exporter(:otel_exporter_pid, self())
-
     MvOpentelemetry.Plug.register_tracer(
       span_prefix: [:harness, :request],
       query_params_whitelist: ["user_id"],

--- a/test/mv_opentelemetry/span_tracer_test.exs
+++ b/test/mv_opentelemetry/span_tracer_test.exs
@@ -4,7 +4,6 @@ defmodule MvOpentelemetry.SpanTracerTest do
   alias MvOpentelemetry.CustomSpanTracer
 
   test "it captures the event" do
-    :otel_batch_processor.set_exporter(:otel_exporter_pid, self())
     CustomSpanTracer.register_tracer()
 
     :telemetry.span([:my_event, :do_stuff], %{name: "custom"}, fn ->
@@ -21,7 +20,6 @@ defmodule MvOpentelemetry.SpanTracerTest do
   end
 
   test "it captures the exception" do
-    :otel_batch_processor.set_exporter(:otel_exporter_pid, self())
     CustomSpanTracer.register_tracer()
 
     try do

--- a/test/support/opentelemetry_case.ex
+++ b/test/support/opentelemetry_case.ex
@@ -32,6 +32,16 @@ defmodule MvOpentelemetry.OpenTelemetryCase do
 
     conn = Phoenix.ConnTest.build_conn()
 
+    # Restart the app between each test and set exporter to current pid
+    :application.stop(:opentelemetry)
+    :application.set_env(:opentelemetry, :tracer, :otel_tracer_default)
+
+    :application.set_env(:opentelemetry, :processors, [
+      {:otel_batch_processor, %{scheduled_delay_ms: 1, exporter: {:otel_exporter_pid, self()}}}
+    ])
+
+    :application.start(:opentelemetry)
+
     {:ok, conn: conn}
   end
 end


### PR DESCRIPTION
The `opentelemetry` app unfortunately is full of global state, so between each test case we need to check reset it's state.