### PR TITLE
This PR removes obsolete attributes from spans

### DIFF
--- a/.known_dialyzer_warnings
+++ b/.known_dialyzer_warnings
@@ -1,5 +1,5 @@
 lib/mv_opentelemetry/ecto.ex:126: The call 'Elixir.OpenTelemetry.Ctx':attach(_context@1::{'span_ctx',non_neg_integer(),non_neg_integer(),'undefined' | integer(),[{_,_}],'false' | 'true' | 'undefined',boolean(),'false' | 'true' | 'undefined','undefined' | {atom(),_}}) will never return since it differs in the 1st argument from the success typing arguments: (map())
 lib/mv_opentelemetry/ecto.ex:129: The variable _context@1 can never match since previous clauses completely covered the type 'undefined'
 lib/mv_opentelemetry/dataloader.ex:81: The call 'Elixir.OpenTelemetry.Ctx':detach(_context@1::map()) does not have an opaque term of type otel_ctx:token() as 1st argument
-lib/mv_opentelemetry/tesla.ex:88: The call 'Elixir.OpenTelemetry.Ctx':detach(_context@1::map()) does not have an opaque term of type otel_ctx:token() as 1st argument
+lib/mv_opentelemetry/tesla.ex:84: The call 'Elixir.OpenTelemetry.Ctx':detach(_context@1::map()) does not have an opaque term of type otel_ctx:token() as 1st argument
 lib/mv_opentelemetry/ecto.ex:142: The call 'Elixir.OpenTelemetry.Ctx':detach(_context@1::map()) does not have an opaque term of type otel_ctx:token() as 1st argument

--- a/lib/mv_opentelemetry/finch.ex
+++ b/lib/mv_opentelemetry/finch.ex
@@ -53,11 +53,7 @@ defmodule MvOpentelemetry.Finch do
     ctx = OpentelemetryTelemetry.set_current_telemetry_span(opts[:tracer_id], meta)
 
     if status do
-      Span.set_attributes(ctx, %{
-        # Remove this field after some time in favour of Trace.http_status_code()
-        :"http.status" => status,
-        Trace.http_status_code() => status
-      })
+      Span.set_attributes(ctx, %{Trace.http_status_code() => status})
     end
 
     if error do

--- a/lib/mv_opentelemetry/oban.ex
+++ b/lib/mv_opentelemetry/oban.ex
@@ -34,7 +34,6 @@ defmodule MvOpentelemetry.Oban do
     attributes = [
       {Trace.messaging_system(), :oban},
       {Trace.messaging_destination(), queue},
-      {Trace.messaging_destination_kind(), :queue},
       {Trace.messaging_operation(), :process},
       {:"messaging.oban.job_id", id},
       {:"messaging.oban.worker", worker},

--- a/lib/mv_opentelemetry/plug.ex
+++ b/lib/mv_opentelemetry/plug.ex
@@ -68,8 +68,6 @@ defmodule MvOpentelemetry.Plug do
 
     attributes = [
       {Trace.http_client_ip(), client_ip},
-      # Remove this field after some time in favour of Trace.net_peer_name()
-      {:"http.host", conn.host},
       {Trace.net_peer_name(), conn.host},
       {Trace.http_method(), conn.method},
       {Trace.http_scheme(), "#{conn.scheme}"},
@@ -110,11 +108,7 @@ defmodule MvOpentelemetry.Plug do
   def handle_stop_event(_, _, %{conn: conn} = meta, opts) do
     ctx = OpentelemetryTelemetry.set_current_telemetry_span(opts[:tracer_id], meta)
 
-    Span.set_attributes(ctx, %{
-      # Remove this field after some time in favour of Trace.http_status_code()
-      :"http.status" => conn.status,
-      Trace.http_status_code() => conn.status
-    })
+    Span.set_attributes(ctx, %{Trace.http_status_code() => conn.status})
 
     if conn.status >= 400 do
       Span.set_status(ctx, OpenTelemetry.status(:error, ""))

--- a/lib/mv_opentelemetry/tesla.ex
+++ b/lib/mv_opentelemetry/tesla.ex
@@ -62,11 +62,7 @@ defmodule MvOpentelemetry.Tesla do
     ctx = OpentelemetryTelemetry.set_current_telemetry_span(opts[:tracer_id], meta)
 
     if status do
-      Span.set_attributes(ctx, %{
-        # Remove this field after some time in favour of Trace.http_status_code()
-        :"http.status" => status,
-        Trace.http_status_code() => status
-      })
+      Span.set_attributes(ctx, %{Trace.http_status_code() => status})
     end
 
     if error do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule MvOpentelemetry.MixProject do
   def project do
     [
       app: :mv_opentelemetry,
-      version: "1.14.0",
+      version: "2.0.0",
       elixir: "~> 1.14",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: Mix.compilers(),

--- a/test/mv_opentelemetry/finch_test.exs
+++ b/test/mv_opentelemetry/finch_test.exs
@@ -57,8 +57,6 @@ defmodule MvOpentelemetry.FinchTest do
     assert :client == span(span_record, :kind)
 
     assert {:"http.status_code", 200} in attributes
-    assert {:"http.status", 200} in attributes
-    assert {:"http.host", "localhost"} in attributes
     assert {:"net.peer.name", "localhost"} in attributes
     assert {:"http.method", "GET"} in attributes
     assert {:"http.target", "/"} in attributes

--- a/test/mv_opentelemetry/oban_test.exs
+++ b/test/mv_opentelemetry/oban_test.exs
@@ -22,7 +22,6 @@ defmodule MvOpentelemetry.ObanTest do
     assert {:"messaging.system", :oban} in attributes
     assert {:"messaging.oban.attempt", 1} in attributes
     assert {:"messaging.destination", "events"} in attributes
-    assert {:"messaging.destination_kind", :queue} in attributes
     assert {:"messaging.oban.priority", 0} in attributes
     assert {:"messaging.oban.inserted_at", nil} in attributes
     assert {:"messaging.system", :oban} in attributes

--- a/test/mv_opentelemetry/plug_test.exs
+++ b/test/mv_opentelemetry/plug_test.exs
@@ -16,11 +16,9 @@ defmodule MvOpentelemetry.PlugTest do
     {:attributes, _, _, _, attributes} = span(span_record, :attributes)
     keys = Enum.map(attributes, fn {k, _v} -> k end)
 
-    assert {:"http.status", 200} in attributes
     assert {:"http.status_code", 200} in attributes
     assert {:"http.method", "GET"} in attributes
     assert {:"http.flavor", ""} in attributes
-    assert {:"http.host", "www.example.com"} in attributes
     assert {:"net.peer.name", "www.example.com"} in attributes
     assert {:"http.target", "/"} in attributes
     assert {"service.component", "test.harness"} in attributes
@@ -77,7 +75,6 @@ defmodule MvOpentelemetry.PlugTest do
     {:attributes, _, _, _, attributes} = span(span_record, :attributes)
     keys = Enum.map(attributes, fn {k, _v} -> k end)
 
-    assert {:"http.status", 200} in attributes
     assert {:"http.status_code", 200} in attributes
     assert {:"http.method", "GET"} in attributes
     assert {:"http.flavor", ""} in attributes


### PR DESCRIPTION
These are already replaced by either `http.status_code` or `net.peer.name` so we are not losing anything. But it is still breaking change, so the version increases to 2.x