### PR TITLE
Housekeeping: Tests and specs

### DIFF
--- a/lib/mv_opentelemetry.ex
+++ b/lib/mv_opentelemetry.ex
@@ -33,6 +33,7 @@ defmodule MvOpentelemetry do
   @type traced_apps ::
           :absinthe
           | :broadway
+          | :cowboy
           | :dataloader
           | :ecto
           | :finch


### PR DESCRIPTION
1. Add a test to ensure query params are logged as string.
2. Add missing atom to type specification.