### PR TITLE
HOTFIX: Log query params as string

### DIFF
--- a/lib/mv_opentelemetry.ex
+++ b/lib/mv_opentelemetry.ex
@@ -80,8 +80,6 @@ defmodule MvOpentelemetry do
     - `span_prefix` OPTIONAL telemetry prefix to listen to. Defaults to [:phoenix, :endpoint]
     - `default_attributes` OPTIONAL property list of attributes you want to attach to all traces
       from this group, for example [{"service.component", "ecto"}]. Defaults to []
-    - `query_params_whitelist` OPTIONAL list of query param names you want to allow to log in your
-      traces, i.e ["user_id", "product_id"]. Defaults to logging all.
 
   ## Broadway
     - `default_attributes` OPTIONAL property list of attributes you want to attach to all traces


### PR DESCRIPTION
Previously we used to log query params as separate values like so:

{"http.query_params.user_id" => "123"}

This unfortunately leads to dataset pollution on honeycomb side if the whitelist isn't configured properly. To resolve this, we would switch to log query params as string, exactly how they are given by the client.

Signed-off-by: Maciej Szlosarczyk (maciej@mindvalley.com)